### PR TITLE
GitHub Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install build packages
+        run: sudo apt-get install -y pandoc texlive-lang-cyrillic texlive-latex-extra lmodern cm-super
+  
+      - name: Make pdf
+        run: |
+          make ru
+          make en
+          make
+
+      - name: GitHub Release creation
+        uses: anton-yurchenko/git-release@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UNRELEASED: "update"
+        with:
+          args: ./*.pdf


### PR DESCRIPTION
Искал документацию и увидел что релиз с pdf от **2019** года, а сами файлы редактировались **last month**.

Написал CI скрипт(Github Action), который собирает pdf автоматически после каждого пуша в мастер и помечает релиз как latest.

<img width="1249" alt="image" src="https://user-images.githubusercontent.com/706291/149347166-7b7ac987-b03f-4f84-ad87-7014b9abb67f.png">


<img width="1291" alt="image" src="https://user-images.githubusercontent.com/706291/149347708-b8fd4930-4dc4-4a8f-9c4e-0bb0afa38082.png">

