### PR TITLE
GitHub Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install build packages
-        run: sudo apt-get install -y pandoc texlive-lang-cyrillic texlive-latex-extra lmodern cm-super
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y --fix-missing pandoc texlive-lang-cyrillic texlive-latex-extra lmodern cm-super
   
       - name: Make pdf
         run: |


### PR DESCRIPTION
Предыдущий workflow упал так как не установились пакеты в раннере, хотя тот же самый workflow в моем репозитории сработал успешно. Возможно это был проблемный раннер, и перезапуск action помог бы.

Но лучше явно сделать `apt update`, а так же добавил `--fix-missing`.

https://github.com/embox/embox-docs/runs/4805381439?check_suite_focus=true
https://github.com/stan-kondrat/embox-docs/runs/4804427745?check_suite_focus=true